### PR TITLE
Increase apiserver mem-threshold in density test

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -166,7 +166,7 @@ func density30AddonResourceVerifier(numNodes int) map[string]framework.ResourceC
 	} else {
 		if numNodes <= 100 {
 			apiserverCPU = 1.8
-			apiserverMem = 1500 * (1024 * 1024)
+			apiserverMem = 1700 * (1024 * 1024)
 			controllerCPU = 0.5
 			controllerMem = 500 * (1024 * 1024)
 			schedulerCPU = 0.4


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/60500#issuecomment-372682659

/sig scalability
/kind bug
/cc @wojtek-t
/cc @crassirostris (for the release-note)

```release-note
Buffering introduced to audit-logging can lead to increased apiserver memory usage. We saw upto 200MB increase in our 100-node cluster performance tests. Ref: issue#60500
```